### PR TITLE
chore: specify lean3port revision

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -53,6 +53,6 @@ package mathlib3port (dir) {
   defaultFacet := PackageFacet.oleans
   dependencies := #[{
     name := "lean3port",
-    src := Source.git "https://github.com/leanprover-community/lean3port.git" "master"
+    src := Source.git "https://github.com/leanprover-community/lean3port.git" "fc17055f3535e176358f651af1eefb5f6ede0f84"
   }]
 }


### PR DESCRIPTION
If the revision is not specified explicitly, then `git pull && lake build` won't update lean3port and mathlib4.